### PR TITLE
Accessing element using first instead of subscript with index 0

### DIFF
--- a/ExposureApp/CRExposureNotification/ViewControllers/TabbarController.swift
+++ b/ExposureApp/CRExposureNotification/ViewControllers/TabbarController.swift
@@ -10,12 +10,21 @@ class TabbarController: UITabBarController {
     }
     
     public func languageChanged(){
-        if let controller = self.viewControllers?[0]{
+        if let controller = self.viewControllers?.first {
             controller.title = "TabbarController.Exposures".localized()
         }
         
-        if let controller = self.viewControllers?[1]{
+        if let controller = self.viewControllers?.elementOrNil(at: 1) {
             controller.title = "TabbarController.NotifyOthers".localized()
         }
+    }
+}
+
+public extension Array {
+    func elementOrNil(at index: Int) -> Element? {
+        guard indices.contains(index) else {
+            return nil
+        }
+        return self[index]
     }
 }

--- a/ExposureApp/CRExposureNotification/Views/EntryView.swift
+++ b/ExposureApp/CRExposureNotification/Views/EntryView.swift
@@ -69,12 +69,13 @@ class EntryView: UIView, UITextFieldDelegate {
         stackView.alignment = .center
         stackView.spacing = 8.0
         stackView.accessibilityLabel = label.accessibilityLabel
-        stackView.accessibilityTraits = textFields[0].accessibilityTraits
+        if let firstTextField = textFields.first {
+            stackView.accessibilityTraits = firstTextField.accessibilityTraits
+        }
         stackView.isAccessibilityElement = true
         
-        let textField1 = textFields[0]
-        stackView.activate = {
-            textField1.becomeFirstResponder()
+        stackView.activate = { [weak self] in
+            self?.textFields.first?.becomeFirstResponder()
         }
         self.stackView = stackView
         addSubview(stackView)

--- a/ExposureApp/CRExposureNotification/Views/Loader/Loader.swift
+++ b/ExposureApp/CRExposureNotification/Views/Loader/Loader.swift
@@ -28,7 +28,9 @@ class Loader: UIView {
     func loadViewFromNib() -> UIView {
         let bundle = Bundle(for: Loader.self)
         let nib = UINib(nibName: className, bundle: bundle)
-        let view = nib.instantiate(withOwner: self, options: nil).first as! UIView
+        guard let view = nib.instantiate(withOwner: self, options: nil).first as? UIView else {
+            fatalError("Unexpected Logic Error. \(nib) view not found.")
+        }
         return view
     }
     

--- a/ExposureApp/CRExposureNotification/Views/Loader/Loader.swift
+++ b/ExposureApp/CRExposureNotification/Views/Loader/Loader.swift
@@ -28,7 +28,7 @@ class Loader: UIView {
     func loadViewFromNib() -> UIView {
         let bundle = Bundle(for: Loader.self)
         let nib = UINib(nibName: className, bundle: bundle)
-        let view = nib.instantiate(withOwner: self, options: nil)[0] as! UIView
+        let view = nib.instantiate(withOwner: self, options: nil).first as! UIView
         return view
     }
     


### PR DESCRIPTION
In places where **"if let"** is being used with accessing elements via subscript **[0]** I changed it to use **.first**.
I also added helper method **elementOrNil** that returns element at index if there is one or nil if there is none.

There are many places where elements of arrays are accesses via explicit subscript, for example **[1]**, I did not change those parts, but I would suggest that you tweak those parts also. And go thru the project and cleanup places where you use forced unwraps.